### PR TITLE
CMakeLists: allow GCC 4.9.2 (down from GCC 4.9.3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,8 @@ endif()
 
 # Detect minimum compiler version
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.3)
-    message(FATAL_ERROR "GCC 4.9.3 or higher is required")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.2)
+    message(FATAL_ERROR "GCC 4.9.2 or higher is required")
   endif()
   set(GNU TRUE)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")


### PR DESCRIPTION
It works at least on Fedora 21.

**By submitting this pull-request, I confirm the following:**

- I have read and understood the [Contributing Guide](https://github.com/monero-project/kovri/blob/master/doc/CONTRIBUTING.md).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.

*Place an X inside the bracket (or click the box in preview) to confirm*
- [ ] I confirm.

---

*Enter your pull-request summary here*
