### PR TITLE
Build: include Boost before Boost.Python

### DIFF
--- a/contrib/python/CMakeLists.txt
+++ b/contrib/python/CMakeLists.txt
@@ -36,7 +36,7 @@ add_library(kovri_python SHARED
   util.cc)
 
 target_link_libraries(kovri_python PRIVATE kovri-private
-  ${PYTHON_LIBRARIES})
+  ${Boost_LIBRARIES} ${PYTHON_LIBRARIES})
 
 # Use unity targets if they are available
 foreach(_target IN ITEMS kovri-core kovri-client)


### PR DESCRIPTION
Needed for CMake to recognize the dependency.


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

