### PR TITLE
SSU: raise exceptions on null intro key

### DIFF
--- a/src/core/router/transports/ssu/session.cc
+++ b/src/core/router/transports/ssu/session.cc
@@ -1514,10 +1514,17 @@ bool SSUSession::Validate(
 
 void SSUSession::Connect() {
   if (m_State == SessionState::Unknown) {
-    // set connect timer
-    ScheduleConnectTimer();
-    m_DHKeysPair = transports.GetNextDHKeysPair();
-    SendSessionRequest();
+    try
+      {
+        // set connect timer
+        ScheduleConnectTimer();
+        m_DHKeysPair = transports.GetNextDHKeysPair();
+        SendSessionRequest();
+      }
+    catch (...)
+      {
+        m_Exception.Dispatch(__func__);
+      }
   }
 }
 
@@ -1657,6 +1664,9 @@ const std::uint8_t* SSUSession::GetIntroKey() const
       auto* const address =
           m_RemoteRouter->GetAddress(m_RemoteRouter->HasV6(), Transport::SSU);
       assert(address);  // TODO(anonimal): SSU should be guaranteed
+      if (!address)
+        throw std::runtime_error(
+            __func__ + std::string(": null remote address"));
       return address->key;
     }
 
@@ -1665,6 +1675,8 @@ const std::uint8_t* SSUSession::GetIntroKey() const
   const auto* address = context.GetRouterInfo().GetAnyAddress(
       context.GetRouterInfo().HasV6(), Transport::SSU);
   assert(address);  // TODO(anonimal): SSU should be guaranteed
+  if (!address)
+    throw std::runtime_error(__func__ + std::string(": null local address"));
   return address->key;
 }
 


### PR DESCRIPTION
Raises exceptions after failing to retrieve an introducer key.


---
**By submitting this pull-request, I confirm the following:**

- I have read and understood the developer guide in [kovri-docs](https://github.com/monero-project/kovri-docs).
- I have checked that another pull-request for this purpose does not exist.
- I have considered and confirmed that this submission will be valuable to others.
- I accept that this submission may not be used and that this pull-request may be closed by the will of the maintainer.
- I give this submission freely under the BSD 3-clause license.
---

